### PR TITLE
Hotfix for mtp wierd behaviors (should fix mtp unstability)

### DIFF
--- a/device_m2note.mk
+++ b/device_m2note.mk
@@ -165,5 +165,4 @@ ADDITIONAL_DEFAULT_PROPERTIES += \
 	ro.debuggable=1 \
 	ro.adb.secure=1 \
 	persist.service.acm.enable=0 \
-	ro.oem_unlock_supported=1 \
-	persist.sys.usb.config=mtp
+	ro.oem_unlock_supported=1

--- a/system.prop
+++ b/system.prop
@@ -36,11 +36,10 @@ dalvik.vm.heapsize=512m
 
 # USB MTP WHQL
 ro.sys.usb.mtp.whql.enable=0
+ro.sys.usb.storage.type=mtp,mass_storage
 
 # Power off opt in IPO
 sys.ipo.pwrdncap=2
-
-ro.sys.usb.storage.type=mtp,mass_storage
 
 # USB BICR function
 ro.sys.usb.bicr=yes


### PR DESCRIPTION
don't use :
  ro.sys.usb.storage.type=mtp
in device_m2note.mk because it is then moved inside default.prop causing a lot of trouble during boot